### PR TITLE
Improved URL → Cloud Storage handling

### DIFF
--- a/backends/gcs/get.go
+++ b/backends/gcs/get.go
@@ -53,7 +53,7 @@ func ReadWithCache(ctx context.Context, response http.ResponseWriter,
 	request *http.Request, missPipeline filter.Pipeline, cacheGet CacheGet,
 	hitPipeline filter.Pipeline) {
 	// normalize path
-	objectName := common.NormalizeURL(request.URL.String())
+	objectName := common.NormalizeURL(request.URL.Path)
 
 	// get the object handle and headers. Headers are always cached and obey
 	// Cache-Control header, so this will not call GCS unless there's a miss.

--- a/backends/gcs/get.go
+++ b/backends/gcs/get.go
@@ -53,7 +53,7 @@ func ReadWithCache(ctx context.Context, response http.ResponseWriter,
 	request *http.Request, missPipeline filter.Pipeline, cacheGet CacheGet,
 	hitPipeline filter.Pipeline) {
 	// normalize path
-	objectName := common.NormalizeURL(request.URL.Path)
+	objectName := common.NormalizePath(request.URL.Path)
 
 	// get the object handle and headers. Headers are always cached and obey
 	// Cache-Control header, so this will not call GCS unless there's a miss.

--- a/common/helpers.go
+++ b/common/helpers.go
@@ -17,17 +17,17 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+    "strings"
 )
 
-// NormalizeURL removes the leading slash from URLs, and also
-// redirects root requests "/" to index.html.
-func NormalizeURL(url string) (object string) {
-	switch url {
-	case "/":
-		return "index.html"
-	default:
-		return url[1:]
-	}
+// NormalizePath:
+//   replace trailing slashes with "/index.html";
+//   remove leading slashes.
+func NormalizePath(path string) (object string) {
+    if strings.HasSuffix(path, "/") {
+        path = path + "index.html"
+    }
+    return strings.TrimLeft(path, "/")
 }
 
 func GetRuntimeProjectId() (string, error) {


### PR DESCRIPTION
Minor improvements to the transformation from request URLs to Cloud Storage paths:

1. If the gcs proxy gets requests with URL queries or fragments, it will ignore them.
2. Any URL with a trailing slash in its path is extended by "index.html"

(1) Better matches the behavior of the default GCP "backend bucket" network services, and is probably more correct (The change to get.go:56)

(2) better matches the default configuration you're likely to want when doing static site hosting out of GCS -- though is admittedly much more opinionated.