### PR TITLE
Add h2c handler to stream files > 32MB

### DIFF
--- a/cmd/gcs-proxy/main.go
+++ b/cmd/gcs-proxy/main.go
@@ -20,12 +20,14 @@ import (
 
 	"github.com/DomZippilli/gcs-proxy-cloud-function/config"
 	"github.com/rs/zerolog/log"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 )
 
 func main() {
 	// initialize
 	log.Print("starting server...")
-	http.HandleFunc("/", ProxyHTTPGCS)
+	handler := http.HandlerFunc(ProxyHTTPGCS)
 
 	// Determine port for HTTP service.
 	port := os.Getenv("PORT")
@@ -41,7 +43,8 @@ func main() {
 
 	// Start HTTP server.
 	log.Printf("listening on port %s", port)
-	if err := http.ListenAndServe(":"+port, nil); err != nil {
+	http2server := &http2.Server{}
+	if err := http.ListenAndServe(":"+port, h2c.NewHandler(handler, http2server)); err != nil {
 		log.Fatal().Msgf("main: %v", err)
 	}
 }

--- a/deploy.sh
+++ b/deploy.sh
@@ -58,6 +58,7 @@ gcloud run deploy "${SERVICE_NAME}" \
     --timeout=300s \
     --platform managed \
     --allow-unauthenticated \
-    --ingress=all
+    --ingress=all \
+    --use-http2
 
 echo Service deployed.


### PR DESCRIPTION
I have added a h2c handler as documented in https://pkg.go.dev/golang.org/x/net@v0.0.0-20210916014120-12bc252f5db8/http2/h2c

I have also changed the deployment to have a cloudRun service in http/2. 

I was able to download a 300MB file, so above the cloudrun http1 limits  https://cloud.google.com/run/quotas#cloud_run_limits

Fixes #9 
