### PR TITLE
Fix/improve shell scripts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -39,7 +39,7 @@ if [[ "${IMAGE_NAME}" == *help ]] || [[ "${IMAGE_NAME}" == "-h" ]]; then
     exit
 fi
 
-gcloud builds submit --tag "${TAG}"
+gcloud --project="${PROJECT}" builds submit --tag "${TAG}"
 
 echo Container image built:
 echo "${TAG}" 

--- a/build.sh
+++ b/build.sh
@@ -26,11 +26,15 @@ function usage(){
     echo >&2
 }
 
-IMAGE_NAME=${1-}
 IMAGE_NAME="${1:-gcs-streaming-proxy}"
-PROJECT=${2-}
-PROJECT="${2:-$(gcloud config get-value project)}"
+PROJECT="${2:-$(gcloud config get-value project 2>/dev/null)}"
 TAG=gcr.io/"${PROJECT}"/"${IMAGE_NAME}"
+
+if [[ -z "$PROJECT" ]]; then
+    echo >&2 "ERROR: Could not determine project. Please specify it explicitly."
+    usage
+    exit 2
+fi
 
 # quick and dirty way to catch if the user asks for help, like --help
 # downside: you can't tag the image as *help or just "-h"

--- a/deploy.sh
+++ b/deploy.sh
@@ -34,12 +34,15 @@ function usage(){
 
 BUCKET_NAME=${1?$(usage)}
 REGION=${2?$(usage)}
-PROJECT=${3-}
-PROJECT="${3:-$(gcloud config get-value project)}"
-IMAGE_NAME=${4-}
+PROJECT="${3:-$(gcloud config get-value project 2>/dev/null)}"
 IMAGE_NAME="${4:-gcr.io/${PROJECT}/gcs-streaming-proxy}"
-SERVICE_NAME=${5-}
 SERVICE_NAME="${5:-gcs-${BUCKET_NAME}}"
+
+if [[ -z "$PROJECT" ]]; then
+    echo >&2 "ERROR: Could not determine project. Please specify it explicitly."
+    usage
+    exit 2
+fi
 
 # quick and dirty way to catch if the user asks for help, like --help
 # downside: you can't tag the image as *help or just "-h"


### PR DESCRIPTION
1. Fix `build.sh` to adhere to the given project argument
2. Make `build.sh` and `deploy.sh` exit early if no project was specified by the user *and* no default project could be determined.  (`gcloud config get-value project` exits successfully, even when it can not return a project, so the scripts must check for an empty string, not an exit code.)
