### PR TITLE
Remove `--use-http2` flag

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -63,7 +63,6 @@ gcloud run deploy "${SERVICE_NAME}" \
     --timeout=300s \
     --platform managed \
     --allow-unauthenticated \
-    --ingress=all \
-    --use-http2
+    --ingress=all
 
 echo Service deployed.


### PR DESCRIPTION
A major use case for this repo is to enable IAP for access to data in GCS buckets. However, [IAP is currently incompatible with http/2](https://cloud.google.com/iap/docs/enabling-cloud-run#known_limitations), which results in an infinite redirect loop. This change reverts to the default deployment without http/2 enabled.