### PR TITLE
feat: handle if-none-match header and also send etag to client

### DIFF
--- a/backends/gcs/headers.go
+++ b/backends/gcs/headers.go
@@ -55,6 +55,9 @@ func setHeaders(ctx context.Context, objectHandle *storage.ObjectHandle,
 	if objectAttrs.ContentType != "" {
 		response.Header().Set("Content-Type", objectAttrs.ContentType)
 	}
+	if objectAttrs.Etag != "" {
+		response.Header().Set("Etag", objectAttrs.Etag)
+	}
 	response.Header().Set("Content-Length", fmt.Sprint(objectAttrs.Size))
 	return
 }


### PR DESCRIPTION
This will add etag support to GET requests. 

* send the etag along in the response headers
* test for "if-none-match" header and compare the values to the etag from GCS. 

I'm a go newbie, so feel free to correct or ask for corrections where something doesn't fit in the schema.